### PR TITLE
Avoid java.lang.IndexOutOfBoundsException

### DIFF
--- a/client/src/main/java/br/com/caelum/restfulie/http/apache/ApacheHeaders.java
+++ b/client/src/main/java/br/com/caelum/restfulie/http/apache/ApacheHeaders.java
@@ -23,7 +23,7 @@ public class ApacheHeaders implements Headers {
 	}
 
 	public String getMain(String key) {
-		return response.getHeaders(key)[0].getValue().split(";")[0];
+		return getFirst(key).split(";")[0];
 	}
 
 	public List<String> get(String key) {
@@ -36,7 +36,8 @@ public class ApacheHeaders implements Headers {
 	}
 
 	public String getFirst(String key) {
-		return get(key).get(0);
+		Header[] headers = response.getHeaders(key);
+		return headers != null && headers.length > 0 ? get(key).get(0) : "";
 	}
 
 	public List<Link> links() {

--- a/client/src/main/java/br/com/caelum/restfulie/http/apache/ApacheResponse.java
+++ b/client/src/main/java/br/com/caelum/restfulie/http/apache/ApacheResponse.java
@@ -54,14 +54,14 @@ public class ApacheResponse implements Response {
 	}
 
 	public <T> T getResource() throws IOException {
-		String contentType = getContentType();
+		String contentType = getType();
 		String content = getContent();
 		return (T) client.getMediaTypes().forContentType(contentType)
 				.unmarshal(content, client);
 	}
 
-	private String getContentType() throws IOException {
-		return getHeader("Content-Type").get(0).split(";")[0];
+	public String getType() {
+		return getHeaders().getMain("Content-Type");
 	}
 
 	public Headers getHeaders() {
@@ -74,14 +74,14 @@ public class ApacheResponse implements Response {
 
 	public URI getLocation() {
 		try {
-			return new URI(response.getHeaders("Location")[0].getValue());
+			String location = getHeaders().getFirst("Location");
+			if(location == null || location.equals(""))
+				return getRequest().getURI();
+			else
+				return new URI(location);
 		} catch (URISyntaxException e) {
 			throw new RestfulieException("Invalid URI received as a response", e);
 		}
-	}
-
-	public String getType() {
-		return response.getHeaders("Content-Type")[0].getValue();
 	}
 
 	public Request getRequest() {

--- a/client/src/test/java/br/com/caelum/restfulie/http/apache/ApacheHeadersTest.java
+++ b/client/src/test/java/br/com/caelum/restfulie/http/apache/ApacheHeadersTest.java
@@ -3,12 +3,15 @@ package br.com.caelum.restfulie.http.apache;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.apache.http.Header;
+import org.apache.http.HeaderElement;
 import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -16,6 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import br.com.caelum.restfulie.Link;
 import br.com.caelum.restfulie.RestClient;
+import br.com.caelum.restfulie.http.Headers;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApacheHeadersTest {
@@ -28,7 +32,51 @@ public class ApacheHeadersTest {
 	
 	@Mock
 	private RestClient client;
-
+	
+	@Test
+	public void shouldGetJustTheFirstInformation()
+	{
+		Headers headers = new ApacheHeaders(response, client);
+		
+		when(response.getHeaders("Content-Type")).thenReturn(headers());
+		assertEquals("text/html", headers.getMain("Content-Type"));
+	}
+	
+	@Test
+	public void shouldReturnEmptyWhenNoneContentTypeIsDeclared()
+	{
+		Headers headers = new ApacheHeaders(response, client);
+		assertEquals("", headers.getFirst("Content-Type"));
+	}
+	
+	private Header[] headers()
+	{
+		return new Header[]{
+			new Header() {
+			
+				@Override
+				public String getValue() { return "text/html"; }
+					
+				@Override
+				public String getName() { return "Content-Type"; }
+					
+				@Override
+				public HeaderElement[] getElements() throws ParseException { return null; }
+			},
+			new Header() {
+					
+				@Override
+				public String getValue() { return "text/xml"; }
+					
+				@Override
+				public String getName() { return "Content-Type"; }
+					
+				@Override
+				public HeaderElement[] getElements() throws ParseException { return null; }
+				}
+		};
+	}
+	
 	@Test
 	public void shouldReturnsAllTheLinksOfTheHeader() {
 		//Given

--- a/client/src/test/java/br/com/caelum/restfulie/http/apache/ApacheResponseTest.java
+++ b/client/src/test/java/br/com/caelum/restfulie/http/apache/ApacheResponseTest.java
@@ -1,0 +1,87 @@
+package br.com.caelum.restfulie.http.apache;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+import br.com.caelum.restfulie.Response;
+import br.com.caelum.restfulie.http.Request;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApacheResponseTest
+{
+	
+	@Mock
+	private Response response;
+	
+	@Mock
+	private Request request;
+	
+	@Mock
+	private HttpResponse mockHttpResponse;
+	
+	@Before
+	public void setUp()
+	{
+		mockHttpResponse = Mockito.mock(HttpResponse.class);
+		response = new ApacheResponse(mockHttpResponse ,null, request);
+	}
+	
+	@Test
+	public void shouldGetResponseType()
+	{
+		when(mockHttpResponse.getHeaders("Content-Type")).thenReturn(new Header[]{new Header() {
+			
+			@Override
+			public String getValue() { return "text/html"; }
+			
+			@Override
+			public String getName() { return "Content-Type"; }
+			
+			@Override
+			public HeaderElement[] getElements() throws ParseException { return null; }
+			}
+		});
+		assertEquals("text/html", response.getType());
+	}
+	
+	@Test
+	public void shouldReturnToOriginalResponseWhenNoneLocationIsDefined() throws URISyntaxException
+	{
+		URI origin = new URI("http://default.com");
+		when(request.getURI()).thenReturn(origin);
+		assertEquals( origin, response.getLocation() );
+	}
+	
+	@Test
+	public void shouldGetResponseLocation() throws URISyntaxException
+	{
+		when(mockHttpResponse.getHeaders("Location")).thenReturn(new Header[]{new Header() {
+			
+			@Override
+			public String getValue() { return "http://example.com"; }
+			
+			@Override
+			public String getName() { return "Location"; }
+			
+			@Override
+			public HeaderElement[] getElements() throws ParseException { return null; }
+			}
+		});
+		assertEquals(new URI("http://example.com"), response.getLocation());
+	}
+}


### PR DESCRIPTION
As commented in this topic:
http://www.guj.com.br/java/232704-resolvido-erro-de-conversao-no-xstream-usando-vraptor-e-restfulie

Question: Is it better return a default value or throw a specific exception in this case?
