### PR TITLE
Fixed typographical error, changed aquire to acquire in README.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -112,7 +112,7 @@ you to retrieve a resource or post to a resource controller:
 
 Due to the nature of the entry point and the java bytecode, Restfulie is still unable to allow the user to make the http verb even more transparent.
 
-As seen earlier, as soon as you have aquired an object through the use of the restfulie api, you can invoke its transitions:
+As seen earlier, as soon as you have acquired an object through the use of the restfulie api, you can invoke its transitions:
 
 <pre>
 Order order = Restfulie.resource("http://www.caelum.com.br/orders/1").get();


### PR DESCRIPTION
@caelum, I've corrected a typographical error in the documentation of the [restfulie-java](https://github.com/caelum/restfulie-java) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.