### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/client/src/main/java/br/com/caelum/restfulie/Restfulie.java
+++ b/client/src/main/java/br/com/caelum/restfulie/Restfulie.java
@@ -32,6 +32,9 @@ import br.com.caelum.restfulie.relation.Enhancer;
  * @author guilherme silveira
  */
 public class Restfulie {
+    
+    private Restfulie() {}
+    
 	
 	/**
 	 * Given an retrieved resource, gives access to restfulie's transition api.

--- a/client/src/main/java/br/com/caelum/restfulie/feature/Features.java
+++ b/client/src/main/java/br/com/caelum/restfulie/feature/Features.java
@@ -5,6 +5,8 @@ package br.com.caelum.restfulie.feature;
  * @author jose donizetti
  */
 public class Features {
+    
+    private Features() {}
 	
 	public static ResponseFeature throwError() {
 		return new ThrowError();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed